### PR TITLE
Change html creative third party tracking tags

### DIFF
--- a/lib/ttdrest/concerns/creative_types/flash.rb
+++ b/lib/ttdrest/concerns/creative_types/flash.rb
@@ -27,11 +27,6 @@ module Ttdrest
           end
 
           if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
             flash_data = flash_data.merge({
               ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
             })

--- a/lib/ttdrest/concerns/creative_types/flash.rb
+++ b/lib/ttdrest/concerns/creative_types/flash.rb
@@ -26,6 +26,17 @@ module Ttdrest
             flash_data = flash_data.merge({"IsSecurable" => params[:is_securable]})
           end
 
+          if !params[:third_party_tracking_tags].nil?
+            creative_data = creative_data.merge({
+              ImageAttributes: {
+                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              }
+            })
+            flash_data = flash_data.merge({
+              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+            })
+          end
+
           creative_data = creative_data.merge({"FlashAttributes" => flash_data})
           result = data_post(path, content_type, creative_data.to_json)
           return result

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -91,15 +91,9 @@ module Ttdrest
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-
           if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
             details = details.merge({
-              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+              "ThirdPartyTrackingTags" => [ params[:third_party_tracking_tags] ]
             })
           end
 

--- a/lib/ttdrest/concerns/creative_types/html.rb
+++ b/lib/ttdrest/concerns/creative_types/html.rb
@@ -91,7 +91,6 @@ module Ttdrest
             details = details.merge({"RightMediaOfferTypeId" => params[:right_media_offer_type_id]})
           end
 
-          creative_data = creative_data.merge({"Html5Attributes" => details})
 
           if !params[:third_party_tracking_tags].nil?
             creative_data = creative_data.merge({
@@ -99,7 +98,12 @@ module Ttdrest
                 ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
               }
             })
+            details = details.merge({
+              ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
+            })
           end
+
+          creative_data = creative_data.merge({"Html5Attributes" => details})
 
           data_post(path, content_type, creative_data.to_json)
 

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.28"
+  VERSION = "0.0.29"
 end


### PR DESCRIPTION
This should fix our html5 issue. We were sending a high level tracking tag attribute with ImageAttributes, looks like we are supposed to send it both high level and within html5 attributes for html5 creatives only. We do not support flash anymore, but I have added it to flash creative as well to make sure this error doesn't happen again.