### PR TITLE
removing third party tracking tags from video upload

### DIFF
--- a/lib/ttdrest/concerns/creative_types/video.rb
+++ b/lib/ttdrest/concerns/creative_types/video.rb
@@ -33,14 +33,6 @@ module Ttdrest
 
           creative_data = creative_data.merge({"TradeDeskHostedVideoAttributes" => video_data})
 
-          if !params[:third_party_tracking_tags].nil?
-            creative_data = creative_data.merge({
-              ImageAttributes: {
-                ThirdPartyTrackingTags: [ params[:third_party_tracking_tags] ]
-              }
-            })
-          end
-
           result = data_post(path, content_type, creative_data.to_json)
           return result
         end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.29"
+  VERSION = "0.0.30"
 end


### PR DESCRIPTION
Removes third party tracking tags from video creatives.