### PR TITLE
Allow end date to not be defined and not send nil.

### DIFF
--- a/lib/ttdrest/concerns/campaign.rb
+++ b/lib/ttdrest/concerns/campaign.rb
@@ -53,38 +53,52 @@ module Ttdrest
         if !name.blank?
           campaign_data = campaign_data.merge({"CampaignName" => name})
         end
+
         if !budget.nil?
           campaign_data = campaign_data.merge({"Budget" => budget})
         end
+
         if !start_date.nil?
           campaign_data = campaign_data.merge({"StartDate" => start_date.strftime("%Y-%m-%dT%H:%M:%SZ")})
         end
+
         if !params[:description].nil?
           campaign_data = campaign_data.merge({"Description" => params[:description]})
         end
+
         if !params[:budget_in_impressions].nil?
           campaign_data = campaign_data.merge({"BudgetInImpressions" => params[:budget_in_impressions]})
         end
+
         if !params[:daily_budget].nil?
           campaign_data = campaign_data.merge({"DailyBudget" => params[:daily_budget]})
         end
+
         if !params[:daily_budget_in_impressions].nil?
           campaign_data = campaign_data.merge({"DailyBudgetInImpressions" => params[:daily_budget_in_impressions]})
         end
-        if !params[:end_date].nil?
+
+        # Accepts a date
+        # nil
+        # or, if we're not sending the key, nothing (no update)
+        if params.key?(:end_date) && !params[:end_date].nil?
           campaign_data = campaign_data.merge({"EndDate" => params[:end_date].strftime("%Y-%m-%dT%H:%M:%SZ")})
-        else
+        elsif params.key?(:end_date)
           campaign_data = campaign_data.merge({"EndDate" => nil})
         end
+
         if !params[:availability].nil?
           campaign_data = campaign_data.merge({"Availability" => availability})
         end
+
         if !params[:partner_cost_percentage_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCostPercentageFee" => params[:partner_cost_percentage_fee]})
         end
+
         if !params[:partner_cpm_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCPMFee" => params[:partner_cpm_fee]})
         end
+
         if !params[:partner_cpc_fee].nil?
           campaign_data = campaign_data.merge({"PartnerCPCFee" => params[:partner_cpc_fee]})
         end

--- a/lib/ttdrest/version.rb
+++ b/lib/ttdrest/version.rb
@@ -1,3 +1,3 @@
 module Ttdrest
-  VERSION = "0.0.30"
+  VERSION = "0.0.31"
 end

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -1,0 +1,35 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe Ttdrest::Client do
+  describe "with initialized client" do
+    let(:client) { Ttdrest::Client.new }
+
+    describe "#build_campaign_data" do
+      let(:campaign_id) { 1 }
+      let(:name)        { 'My Campaign Name' }
+      let(:budget)      { 1.01 }
+      let(:start_date)  { Date.today }
+
+      context "EndDate" do
+        it 'nil end date sent' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: nil })
+          ).to include({ "EndDate" => nil })
+        end
+
+        it 'date end date sent' do
+          end_date = Date.today
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: end_date })
+          ).to include({ "EndDate" => end_date.strftime("%Y-%m-%dT%H:%M:%SZ") })
+        end
+
+        it 'no date does not include' do
+          expect(
+            client.build_campaign_data(campaign_id, name, budget, start_date, [], { })
+          ).to_not include("EndDate")
+        end
+      end
+    end
+  end
+end

--- a/spec/ttdrest/concerns/campaign_spec.rb
+++ b/spec/ttdrest/concerns/campaign_spec.rb
@@ -11,20 +11,20 @@ describe Ttdrest::Client do
       let(:start_date)  { Date.today }
 
       context "EndDate" do
-        it 'nil end date sent' do
+        it 'sets EndDate to nil when end_date is nil' do
           expect(
             client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: nil })
           ).to include({ "EndDate" => nil })
         end
 
-        it 'date end date sent' do
+        it 'includes a formatted EndDate when a end_date is sent' do
           end_date = Date.today
           expect(
             client.build_campaign_data(campaign_id, name, budget, start_date, [], { end_date: end_date })
           ).to include({ "EndDate" => end_date.strftime("%Y-%m-%dT%H:%M:%SZ") })
         end
 
-        it 'no date does not include' do
+        it 'does not include EndDate when no date is sent' do
           expect(
             client.build_campaign_data(campaign_id, name, budget, start_date, [], { })
           ).to_not include("EndDate")


### PR DESCRIPTION
When we're not updating end date, we want to be able to not send the key.

We still need to be able to create campaigns with 
- an end date
- without an end date (ongoing)

This is brought about by recent additions to validations that require EndDate to not already be expired on update.