### PR TITLE
handle new TTD auth error code

### DIFF
--- a/lib/ttdrest/concerns/base.rb
+++ b/lib/ttdrest/concerns/base.rb
@@ -30,7 +30,8 @@ module Ttdrest
       end
 
       def check_response(response)
-        if response.code.eql?("403")
+        # TTD API Token Error Code Updates : https://api.thetradedesk.com/v3/portal/api/doc/UpgradeSupportArchives#auth-token-error-code-updates
+        if response.code.in?(["401", "403"])
           raise AuthorizationFailedError
         elsif retryable_http_error?(response)
           raise RecoverableHttpError.new('', response)

--- a/spec/ttdrest/concerns/base_spec.rb
+++ b/spec/ttdrest/concerns/base_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe 'Base Concern' do
     end
   end
 
+  describe '#check_response' do
+    it 'raises AuthorizationFailedError when not authorized response (code 401 )' do
+      expect { client.check_response(faux_response.new(code: '401')) }.to raise_error(Ttdrest::AuthorizationFailedError)
+    end
+
+    it 'raises AuthorizationFailedError when not authorized response (legacy code 403 )' do
+      expect { client.check_response(faux_response.new(code: '403')) }.to raise_error(Ttdrest::AuthorizationFailedError)
+    end
+  end
+
   describe '#perform_request' do
     let(:connection) { double() }
     let(:request) { double() }


### PR DESCRIPTION
TTD modified auth error code from 403 -> 401

https://api.thetradedesk.com/v3/portal/api/doc/UpgradeSupportArchives#auth-token-error-code-updates