### PR TITLE
ttd expiry needs to be less than or equal to 25 hours

### DIFF
--- a/lib/ttdrest/concerns/base.rb
+++ b/lib/ttdrest/concerns/base.rb
@@ -148,8 +148,8 @@ module Ttdrest
         end
       end
 
-      # Defaulting to a 1 hour timeout
-      def auth_post(client_login, client_password, expiration_minutes = 60 * 24 * 30)
+      # Defaulting to a 24 hour timeout
+      def auth_post(client_login, client_password, expiration_minutes = 60 * 24)
         begin
           path = "/#{VERSION}/authentication"
           request = Net::HTTP::Post.new(path, initheader = {'Content-Type' =>'application/json'})


### PR DESCRIPTION
As per https://terminus.atlassian.net/jira/software/c/projects/ADX/boards/95?modal=detail&selectedIssue=ADX-170

The expiry on TTD auth tokens cannot be greater than 24 hours, otherwise it will begin to error on 2/15/22.

Previous expiry was 30 days, changed expiry to 24h.